### PR TITLE
Introduced additional package version strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,26 @@ plugins {
 1. Define multiplatform targets (`macos`, `ios`, `tvos`, `watchos`).
 2. Declare a `spm` section with all the necessary package dependencies for each platform.
 3. Add package dependencies with URL link, version and name. This name would be used as an import in the Kotlin project.
+   Plugin supports all package versioning strategies described here: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html
+   and provides convenient methods to define them:
+   
+   ```
+   fun fromVersion(version: String)
 
+   fun exactVersion(version: String)
+
+   fun versionRange(minVersion: String, maxVersion: String)
+
+   fun versionClosedRange(minVersion: String, maxVersion: String)
+
+   fun upToNextMajor(version: String)
+
+   fun upToNextMinor(version: String)
+
+   fun branch(branchName: String)
+
+   fun revision(ref: String)
+   ```
    `build.gradle.kts` example:
 
    ```kotlin
@@ -34,7 +53,7 @@ plugins {
                dependencies {
                    packages(
                        url = "https://github.com/AFNetworking/AFNetworking.git",
-                       version = "4.0.0",
+                       version = exactVersion("4.0.0"),
                        name = "AFNetworking"
                    )
                }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
             dependencies {
                 packages(
                     url = "https://github.com/AFNetworking/AFNetworking.git",
-                    version = "4.0.0",
+                    version = exactVersion("4.0.1"),
                     name = "AFNetworking"
                 )
             }

--- a/plugin-build/buildSrc/src/main/java/Coordinates.kt
+++ b/plugin-build/buildSrc/src/main/java/Coordinates.kt
@@ -1,7 +1,7 @@
 object PluginCoordinates {
     const val GROUP = "com.github.pagr0m"
     const val ARTIFACT = "kotlin.native.spm"
-    const val VERSION = "0.1.1"
+    const val VERSION = "0.1.2"
 
     const val ID = "$GROUP.$ARTIFACT"
     const val IMPLEMENTATION_CLASS = "$ID.plugin.KotlinSpmPlugin"

--- a/plugin-build/plugin/src/main/java/com/github/pagr0m/kotlin/native/spm/entity/impl/DependencyManager.kt
+++ b/plugin-build/plugin/src/main/java/com/github/pagr0m/kotlin/native/spm/entity/impl/DependencyManager.kt
@@ -36,6 +36,14 @@ class DependencyManager {
 
     fun versionClosedRange(minVersion: String, maxVersion: String) = "\"$minVersion\"...\"$maxVersion\""
 
+    fun upToNextMajor(version: String) = ".upToNextMajor(from: \"$version\")"
+
+    fun upToNextMinor(version: String) = ".upToNextMinor(from: \"$version\")"
+
+    fun branch(branchName: String) = ".branch(\"$branchName\")"
+
+    fun revision(ref: String) = ".revision(\"$ref\")"
+
     data class Package(
         @Input val url: String,
         @Input @Optional val version: String? = null,

--- a/plugin-build/plugin/src/main/java/com/github/pagr0m/kotlin/native/spm/entity/impl/DependencyManager.kt
+++ b/plugin-build/plugin/src/main/java/com/github/pagr0m/kotlin/native/spm/entity/impl/DependencyManager.kt
@@ -24,6 +24,18 @@ class DependencyManager {
         dependencies.add(dependency)
     }
 
+    /**
+     * Version definitions based on:
+     * https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html
+     */
+    fun fromVersion(version: String) = "from: \"$version\""
+
+    fun exactVersion(version: String) = ".exact(\"$version\")"
+
+    fun versionRange(minVersion: String, maxVersion: String) = "\"$minVersion\"..<\"$maxVersion\""
+
+    fun versionClosedRange(minVersion: String, maxVersion: String) = "\"$minVersion\"...\"$maxVersion\""
+
     data class Package(
         @Input val url: String,
         @Input @Optional val version: String? = null,
@@ -38,7 +50,7 @@ class DependencyManager {
                 .package(
                     name: "$dependencyName",
                     url: "$url",
-                    from: "$version"
+                    $version
                 )
             """.trimIndent()
         }


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Current implementation hardcodes and thus supports only one package versioning strategy - `from`.
Use cases of plugin might require support whole bunch of different versioning strategies described here:
https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html



## 📄 Motivation and Context
This change attempts to introduce supporting them while still keeping plugin UX friendly. 

## 🧪 How Has This Been Tested?
I haven't introduced any additional unit tests to cover new logic, instead - performed smoke tests across all new strategies locally. Please do let me know if additional coverage is required. 

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.